### PR TITLE
Fix license info in meta

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: ansistrano
   description: Ansible role to rollback scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
   company: Ansistrano
-  license: BSD
+  license: MIT
   min_ansible_version: 1.6
   platforms:
   - name: EL


### PR DESCRIPTION
The LICENSE file is MIT, not BSD
