### PR TITLE
Get release path variable

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -18,3 +18,7 @@
 - name: ANSISTRANO | Get previous releases version
   shell: echo `ls {{ ansistrano_releases_path.stdout }} -1t | head -n 2 | tail -n 1`
   register: ansistrano_previous_release_version
+
+- name: ANSISTRANO | Get release path
+  command: echo "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_previous_release_version.stdout }}"
+  register: ansistrano_release_path


### PR DESCRIPTION
To share custom tasks between the deploy and rollback.

Example hook:

ansistrano_after_cleanup_tasks_file

```
- name: doctrine:cache:clear-metadata
  shell: chdir={{ ansistrano_release_path.stdout }}
    php app/console doctrine:cache:clear-metadata --env={{dp_sf_env}} --no-debug

```
