### PR TITLE
Rollback to specific release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ dist: trusty
 
 matrix:
   include:
-    - env: ANSIBLE_VERSION=1.8.4
     - env: ANSIBLE_VERSION=1.9.5
-    - env: ANSIBLE_VERSION=2.1.0
+    - env: ANSIBLE_VERSION=2.1.2
+    - env: ANSIBLE_VERSION=2.2.1
 
 before_install:
  - sudo apt-get -y install software-properties-common

--- a/README.md
+++ b/README.md
@@ -168,20 +168,7 @@ In order to rollback with Ansistrano, you need to set up the deployment and run 
 
 If you try to roll back with zero or one releases deployed, an error will be raised and no actions performed.
 
-Variables you can tune in rollback role are less than in deploy one:
-
-```yaml
-- vars:
-  ansistrano_deploy_to: "/var/www/my-app" # Base path to deploy to.
-  ansistrano_version_dir: "releases" # Releases folder name
-  ansistrano_current_dir: "current" # Softlink name. You should rarely changed it.
-
-  # Hooks: custom tasks if you need them
-  ansistrano_before_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-symlink-tasks.yml"
-  ansistrano_after_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-symlink-tasks.yml"
-  ansistrano_before_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-cleanup-tasks.yml"
-  ansistrano_after_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-cleanup-tasks.yml"
-```
+Variables you can tune in rollback role are less than in deploy one, see [Role variables](#role-variables).
 
 Multistage environment (devel, preprod, prod, etc.)
 ---------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Role Variables
   ansistrano_deploy_to: "/var/www/my-app" # Base path to deploy to.
   ansistrano_version_dir: "releases" # Releases folder name
   ansistrano_current_dir: "current" # Softlink name. You should rarely changed it.
+  ansistrano_rollback_to_release: "" # If specified, the application will be rolled back to this release version; previous release otherwise.
   ansistrano_remove_rolled_back: yes # You can change this setting in order to keep the rolled back release in the server for later inspection
   ansistrano_allow_anonymous_stats: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ ansistrano_current_dir: "current"
 # Remove rolled back release?
 ansistrano_remove_rolled_back: yes
 
+# Rollback to this release version (previous by default)
+ansistrano_rollback_to_release: ""
+
 # Sends anonymous stats to the www.ansistrano.com servers
 # You can disallow it by just setting this parameter to "no" in your playbook
 ansistrano_allow_anonymous_stats: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,10 @@
 ---
 galaxy_info:
   author: ansistrano
-  description: Ansible role to roll back scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
+  description: Ansible role to rollback scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
   company: Ansistrano
   license: MIT
-  min_ansible_version: 1.6
+  min_ansible_version: 1.9
   platforms:
   - name: EL
     versions:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -16,10 +16,24 @@
   shell: echo `ls -1t {{ ansistrano_releases_path.stdout }} | head -n 1`
   register: ansistrano_current_release_version
 
+- stat:
+    path: "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_rollback_to_release }}"
+  register: stat_rollback_release_version
+  when: ansistrano_rollback_to_release != ""
+
+- name: ANSISTRANO | Check that the provided rollback release exists
+  fail:
+    msg: "Specified rollback version does not exist"
+  when: ansistrano_rollback_to_release != "" and (stat_rollback_release_version.stat.exists is not defined or stat_rollback_release_version.stat.isdir == False)
+
 - name: ANSISTRANO | Get previous releases version
   shell: echo `ls -1t {{ ansistrano_releases_path.stdout }} | head -n 2 | tail -n 1`
   register: ansistrano_previous_release_version
 
+- name: ANSISTRANO | Get rollback release version
+  set_fact:
+    ansistrano_rollback_release_version: "{{ ansistrano_rollback_to_release if ansistrano_rollback_to_release != '' else ansistrano_previous_release_version.stdout }}"
+
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_previous_release_version.stdout }}"
+  command: echo "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_rollback_release_version }}"
   register: ansistrano_release_path

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -3,4 +3,4 @@
   file:
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
-    src: "./{{ ansistrano_version_dir }}/{{ ansistrano_previous_release_version.stdout }}"
+    src: "./{{ ansistrano_version_dir }}/{{ ansistrano_rollback_release_version }}"


### PR DESCRIPTION
Hi guys, thanks for Ansistrano!

This PR adds a feature to rollback to some specific release version (therefore, it fixes #10). I would like to hear someone's opinion/feedback on the approach first, so I haven't updated READMEs yet. 
Essentially (and unsurprisingly), the idea is to specify the release you want to rollback to (e.g., "20170305132734Z") in the `ansistrano_rollback_to_release` variable. If the version exists, we set the symlink to it. 