### PR TITLE
Replace deprecated 'sudo' Ansible directive by 'become'

### DIFF
--- a/tasks/anon-stats.yml
+++ b/tasks/anon-stats.yml
@@ -9,4 +9,4 @@
   run_once: true
   ignore_errors: yes
   delegate_to: 127.0.0.1
-  sudo: false
+  become: false


### PR DESCRIPTION
This patch prevents a depreciation warning from appearing in newesst Ansible versions and remains compatible with Ansible 1.9+.