### PR TITLE
remove web softlink

### DIFF
--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -1,5 +1,5 @@
 ---
-- name: ANSISTRANO | Change web softlink from current release to previous one
+- name: ANSISTRANO | Change symlink from current release to a previous one
   file:
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"


### PR DESCRIPTION
Because:
- this has nothing to do with `web`
- we call the link `symlink`, not `softlink` everywhere else
- we can rollback to `a` previous version, not only `the` previous one