### PR TITLE
Changed hook var names to not conflict when used with deploy role

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ vars:
   ansistrano_allow_anonymous_stats: yes
 
   # Hooks: custom tasks if you need them
-  ansistrano_before_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-symlink-tasks.yml"
-  ansistrano_after_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-symlink-tasks.yml"
-  ansistrano_before_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-cleanup-tasks.yml"
-  ansistrano_after_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-cleanup-tasks.yml"
+  ansistrano_rollback_before_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-rollback-before-symlink-tasks.yml"
+  ansistrano_rollback_after_symlink_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-rollback-after-symlink-tasks.yml"
+  ansistrano_rollback_before_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-rollback-before-cleanup-tasks.yml"
+  ansistrano_rollback_after_cleanup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-rollback-after-cleanup-tasks.yml"
 ```
 
 `{{ playbook_dir }}` is an Ansible variable that holds the path to the current playbook.
@@ -209,7 +209,7 @@ For example, in order to restart apache after `Symlink` step, we'll add in the `
 * **Q: Where would you add sending email notification after a deployment?**
 * **Q: (for PHP and Symfony developers) Where would you clean the cache?**
 
-You can specify a custom tasks file for before and after every step using `ansistrano_before_*_tasks_file` and `ansistrano_after_*_tasks_file` role variables. See "Role Variables" for more information.
+You can specify a custom tasks file for before and after every step using `ansistrano_rollback_before_*_tasks_file` and `ansistrano_rollback_after_*_tasks_file` role variables. See "Role Variables" for more information.
 
 Variables in custom tasks
 -------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- include: "{{ ansistrano_rollback_before_setup_tasks_file | default('empty.yml') }}"
-- include: setup.yml
-- include: "{{ ansistrano_rollback_after_setup_tasks_file | default('empty.yml') }}"
+- include_tasks: "{{ ansistrano_rollback_before_setup_tasks_file | default('empty.yml') }}"
+- include_tasks: setup.yml
+- include_tasks: "{{ ansistrano_rollback_after_setup_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_rollback_before_symlink_tasks_file | default('empty.yml') }}"
-- include: symlink.yml
-- include: "{{ ansistrano_rollback_after_symlink_tasks_file | default('empty.yml') }}"
+- include_tasks: "{{ ansistrano_rollback_before_symlink_tasks_file | default('empty.yml') }}"
+- include_tasks: symlink.yml
+- include_tasks: "{{ ansistrano_rollback_after_symlink_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_rollback_before_cleanup_tasks_file | default('empty.yml') }}"
-- include: cleanup.yml
-- include: "{{ ansistrano_rollback_after_cleanup_tasks_file | default('empty.yml') }}"
+- include_tasks: "{{ ansistrano_rollback_before_cleanup_tasks_file | default('empty.yml') }}"
+- include_tasks: cleanup.yml
+- include_tasks: "{{ ansistrano_rollback_after_cleanup_tasks_file | default('empty.yml') }}"
 
-- include: anon-stats.yml
+- include_tasks: anon-stats.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,16 @@
     msg: "ansistrano_custom_tasks_path is not used anymore. Please, check the documentation at https://github.com/ansistrano/deploy"
   when: ansistrano_custom_tasks_path is defined
 
-- include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_before_setup_tasks_file | default('empty.yml') }}"
 - include: setup.yml
-- include: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_after_setup_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_before_symlink_tasks_file | default('empty.yml') }}"
 - include: symlink.yml
-- include: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_after_symlink_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_before_cleanup_tasks_file | default('empty.yml') }}"
 - include: cleanup.yml
-- include: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_rollback_after_cleanup_tasks_file | default('empty.yml') }}"
 
 - include: anon-stats.yml


### PR DESCRIPTION
When the same vars file is shared across ansistrano deploy and rollback roles, custom task files variables conflict. This comportment force Ansible to only use value of te last declaration of custom task file.